### PR TITLE
Missing require for socket_peer

### DIFF
--- a/lib/logstash/inputs/unix.rb
+++ b/lib/logstash/inputs/unix.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 require "logstash/inputs/base"
 require "logstash/namespace"
-require "socket"
+require "logstash/util/socket_peer"
 
 # Read events over a UNIX socket.
 #


### PR DESCRIPTION
Socket is already required in register() method.
Fix for https://logstash.jira.com/browse/LOGSTASH-2238
