### PR TITLE
Make usage of the new stop semantics to properly shutdown the plugin

### DIFF
--- a/spec/inputs/unix_spec.rb
+++ b/spec/inputs/unix_spec.rb
@@ -12,4 +12,40 @@ describe LogStash::Inputs::Unix do
     expect { plugin.register }.to_not raise_error
   end
 
+  describe "when interrupting the plugin" do
+
+    context "#server" do
+      it_behaves_like "an interruptible input plugin" do
+        let(:config) { { "path" => tempfile.path, "force_unlink" => true } }
+      end
+    end
+
+    context "#client" do
+      let(:tempfile)    { "/tmp/sock#{rand(65532)}" }
+      let(:config)      { { "path" => tempfile, "mode" => "client" } }
+      let(:unix_socket) { UnixSocketHelper.new.new_socket(tempfile) }
+      let(:run_forever) { true }
+
+      before(:each) do
+        unix_socket.loop(run_forever)
+      end
+
+      after(:each) do
+        unix_socket.close
+      end
+
+      context "when the unix socket has data to be read" do
+        it_behaves_like "an interruptible input plugin" do
+          let(:run_forever) { true }
+        end
+      end
+
+      context "when the unix socket has no data to be read" do
+        it_behaves_like "an interruptible input plugin" do
+          let(:run_forever) { false }
+        end
+      end
+    end
+
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,33 @@
 # encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
 require 'logstash/inputs/unix'
+
+class UnixSocketHelper
+
+  attr_reader :path
+
+  def initialize
+    @socket = nil
+  end
+
+  def new_socket(path)
+    @path   = path
+    File.unlink if File.exists?(path) && File.socket?(path)
+    @socket = UNIXServer.new(path)
+    self
+  end
+
+  def loop(forever=false)
+    @thread = Thread.new do
+      s = @socket.accept
+      s.puts "hi" while forever
+    end
+    self
+  end
+
+  def close
+    @thread.kill
+    @socket.close
+    File.unlink(path)
+  end
+end


### PR DESCRIPTION
Implements `stop` to return from `run` according to https://github.com/elastic/logstash/issues/3210

Depends on https://github.com/elastic/logstash-devutils/pull/32 and https://github.com/elastic/logstash/pull/3812

Fixes #9 

It keeps track of shutting down properly when the plugin works in server mode and when works in client mode with unix socket having data (readpartial will not block) and when it has no data (readpartial will block).
