### PR TITLE
ensure plugin works with abort_on_exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.2
+ - Make plugin and spec work when Thread.abort_on_exception is true
+
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895

--- a/lib/logstash/inputs/unix.rb
+++ b/lib/logstash/inputs/unix.rb
@@ -125,6 +125,10 @@ class LogStash::Inputs::Unix < LogStash::Inputs::Base
         handle_socket(@client_socket, output_queue)
       end
     end
+  rescue IOError
+    # if stop is called during @server_socket.accept
+    # the thread running `run` will raise an IOError
+    # We catch IOError here and do nothing, just let the method terminate
   end # def run
 
   public

--- a/logstash-input-unix.gemspec
+++ b/logstash-input-unix.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-unix'
-  s.version         = '2.0.1'
+  s.version         = '2.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Read events over a UNIX socket."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,8 +19,12 @@ class UnixSocketHelper
 
   def loop(forever=false)
     @thread = Thread.new do
-      s = @socket.accept
-      s.puts "hi" while forever
+      begin
+        s = @socket.accept
+        s.puts "hi" while forever
+      rescue Errno::EPIPE
+        # ...
+      end
     end
     self
   end


### PR DESCRIPTION
by default the specs run with `Thread.abort_on_exception = false` so in that situation this patch is not needed.
Current `master` will however fail if https://github.com/elastic/logstash-devutils/pull/39 is merged, which is what this patch fixes.
