### PR TITLE
Catch IOError in stop

### DIFF
--- a/lib/logstash/inputs/unix.rb
+++ b/lib/logstash/inputs/unix.rb
@@ -139,5 +139,9 @@ class LogStash::Inputs::Unix < LogStash::Inputs::Base
     else
       @client_socket.close
     end
+  rescue IOError
+    # if socket with @mode == client was closed by the client, an other call to @client_socket.close
+    # will raise an IOError. We catch IOError here and do nothing, just let logstash terminate
+    @logger.warn("Cloud not close socket while Logstash is shutting down. Socket already closed by the other party?", :path => @path)
   end # def stop
 end # class LogStash::Inputs::Unix


### PR DESCRIPTION
If socket with @mode == client was closed by the client, an other call
to @client_socket.close will raise an IOError. We catch this
IOError and let logstash stop without error.
