### PR TITLE
Sets default socket permission to "0774".

### DIFF
--- a/spec/inputs/unix_spec.rb
+++ b/spec/inputs/unix_spec.rb
@@ -47,6 +47,26 @@ describe LogStash::Inputs::Unix do
         unix_socket.close
       end
 
+      context "when file_access_mode has not been configured" do
+        it "should use the default file permission" do
+          plugin = LogStash::Plugin.lookup("input", "unix").new(config)
+
+          expect { plugin.register }.to_not raise_error
+          expect(File.stat(tempfile).mode.to_s(8)[2..5]).to eq("0774")
+        end
+      end
+
+      context "when file_access_mode has been configured" do
+        it "should use the default file permission" do
+          plugin = LogStash::Plugin.lookup("input", "unix").new(
+            config.merge("file_access_mode" => "0000")
+          )
+
+          expect { plugin.register }.to_not raise_error
+          expect(File.stat(tempfile).mode.to_s(8)[2..5]).to eq("0000")
+        end
+      end
+
       context "when the unix socket has data to be read" do
         it_behaves_like "an interruptible input plugin" do
           let(:run_forever) { true }


### PR DESCRIPTION
Extension of what @pineur submitted in https://github.com/logstash-plugins/logstash-input-unix/pull/5

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
