### PR TITLE
 Feat: adjust fields for ECS compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.0
+  - Feat: adjust fields for ECS compatibility [#28](https://github.com/logstash-plugins/logstash-input-unix/pull/28) 
+
 ## 3.0.7
   - Docs: Set the default_codec doc attribute.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -80,10 +80,10 @@ If you never want to timeout, use -1.
 [id="plugins-{type}s-{plugin}-ecs_compatibility"]
 ===== `ecs_compatibility`
 
-* Value type is <<string,string>>
-* Supported values are:
-** `disabled`: uses backwards compatible field names, such as `[host]`
-** `v1`, `v8`: uses fields that are compatible with ECS, such as `[host][name]`
+  * Value type is <<string,string>>
+  * Supported values are:
+    ** `disabled`: uses backwards compatible field names, such as `[host]`
+    ** `v1`, `v8`: uses fields that are compatible with ECS, such as `[host][name]`
 
 Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
 See <<plugins-{type}s-{plugin}-ecs>> for detailed information.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -28,6 +28,21 @@ Like `stdin` and `file` inputs, each event is assumed to be one line of text.
 Can either accept connections from clients or connect to a server,
 depending on `mode`.
 
+[id="plugins-{type}s-{plugin}-ecs"]
+==== Compatibility with the Elastic Common Schema (ECS)
+
+This plugin adds extra fields about the event's source, and can be configured to do so
+in an {ecs-ref}[ECS-compatible] way with <<plugins-{type}s-{plugin}-ecs_compatibility>>.
+These fields are added after the event has been decoded by the appropriate codec,
+and will not overwrite existing values.
+
+|========
+| ECS Disabled | ECS v1 , v8      | Description
+
+| `host`       | `[host][name]`   | The name of the {ls} host that processed the event
+| `path`       | `[file][path]`   | The socket path configured in the plugin
+|========
+
 [id="plugins-{type}s-{plugin}-options"]
 ==== Unix Input Configuration Options
 
@@ -37,6 +52,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |=======================================================================
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-data_timeout>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-force_unlink>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-mode>> |<<string,string>>, one of `["server", "client"]`|No
 | <<plugins-{type}s-{plugin}-path>> |<<string,string>>|Yes
@@ -58,6 +74,44 @@ The 'read' timeout in seconds. If a particular connection is idle for
 more than this timeout period, we will assume it is dead and close it.
 
 If you never want to timeout, use -1.
+
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+* Value type is <<string,string>>
+* Supported values are:
+** `disabled`: uses backwards compatible field names, such as `[host]`
+** `v1`, `v8`: uses fields that are compatible with ECS, such as `[host][name]`
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
+See <<plugins-{type}s-{plugin}-ecs>> for detailed information.
+
+
+**Sample output: ECS enabled**
+[source,ruby]
+-----
+{
+    "@timestamp" => 2021-11-16T13:20:06.308Z,
+    "file" => {
+      "path" => "/tmp/sock41299"
+    },
+    "host" => {
+      "name" => "deus-ex-machina"
+    },
+    "message" => "foo"
+}
+-----
+
+**Sample output: ECS disabled**
+[source,ruby]
+-----
+{
+    "@timestamp" => 2021-11-16T13:20:06.308Z,
+    "path" => "/tmp/sock41299",
+    "host" => "deus-ex-machina",
+    "message" => "foo"
+}
+-----
 
 [id="plugins-{type}s-{plugin}-force_unlink"]
 ===== `force_unlink` 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -31,8 +31,10 @@ depending on `mode`.
 [id="plugins-{type}s-{plugin}-ecs"]
 ==== Compatibility with the Elastic Common Schema (ECS)
 
-This plugin adds extra fields about the event's source, and can be configured to do so
-in an {ecs-ref}[ECS-compatible] way with <<plugins-{type}s-{plugin}-ecs_compatibility>>.
+This plugin adds extra fields about the event's source. 
+Configure the <<plugins-{type}s-{plugin}-ecs_compatibility>> option if you want
+to ensure that these fields are compatible with {ecs-ref}[ECS].
+
 These fields are added after the event has been decoded by the appropriate codec,
 and will not overwrite existing values.
 

--- a/lib/logstash/inputs/unix.rb
+++ b/lib/logstash/inputs/unix.rb
@@ -67,13 +67,11 @@ class LogStash::Inputs::Unix < LogStash::Inputs::Base
             @server_socket = UNIXServer.new(@path)
             return
           rescue Errno::EADDRINUSE, IOError
-            @logger.error("!!!Could not start UNIX server: Address in use",
-                          :path => @path)
+            @logger.error("Could not start UNIX server: address in use", :path => @path)
             raise
           end
         end
-        @logger.error("Could not start UNIX server: Address in use",
-                      :path => @path)
+        @logger.error("Could not start UNIX server: address in use", :path => @path)
         raise
       end
     else # client
@@ -107,11 +105,15 @@ class LogStash::Inputs::Unix < LogStash::Inputs::Base
           output_queue << event
         end
       end
-    rescue => e
-      @logger.debug("Closing connection", :path => @path, :exception => e, :backtrace => e.backtrace)
     rescue Timeout::Error
-      @logger.debug("Closing connection after read timeout", :path => @path)
-    end # begin
+      @logger.info("Closing connection after read timeout", :path => @path)
+    rescue => e
+      if @logger.debug?
+        @logger.debug("Closing connection", :path => @path, :exception => e, :backtrace => e.backtrace)
+      else
+        @logger.info("Closing connection", :path => @path, :exception => e)
+      end
+    end
 
   ensure
     begin

--- a/lib/logstash/inputs/unix.rb
+++ b/lib/logstash/inputs/unix.rb
@@ -48,7 +48,7 @@ class LogStash::Inputs::Unix < LogStash::Inputs::Base
     require "timeout"
 
     if server?
-      @logger.info("Starting unix input listener", :address => "#{@path}", :force_unlink => "#{@force_unlink}")
+      @logger.info("Starting unix input listener", :address => @path, :force_unlink => @force_unlink)
       begin
         @server_socket = UNIXServer.new(@path)
       rescue Errno::EADDRINUSE, IOError
@@ -68,8 +68,8 @@ class LogStash::Inputs::Unix < LogStash::Inputs::Base
         raise
       end
     else # client
-      if @socket_not_present_retry_interval_seconds < 0
-        @logger.warn("Value #{@socket_not_present_retry_interval_seconds} for socket_not_present_retry_interval_seconds is not valid, using default value of 5 instead")
+      if socket_not_present_retry_interval_seconds < 0
+        @logger.warn("Value #{socket_not_present_retry_interval_seconds} for socket_not_present_retry_interval_seconds is not valid, using default value of 5 instead")
         @socket_not_present_retry_interval_seconds = 5
       end
     end
@@ -124,7 +124,7 @@ class LogStash::Inputs::Unix < LogStash::Inputs::Base
       while !stop?
         # Start a new thread for each connection.
         @client_threads << Thread.start(@server_socket.accept) do |s|
-          @logger.debug("Accepted connection", :server => "#{@path}")
+          @logger.debug("Accepted connection", :server => @path)
           handle_socket(s, output_queue)
         end
       end
@@ -136,8 +136,8 @@ class LogStash::Inputs::Unix < LogStash::Inputs::Base
           @logger.debug("Opened connection", :client => @path)
           handle_socket(@client_socket, output_queue)
         else
-          @logger.warn("Socket not present, wait for #{@subscription_retry_interval_seconds} seconds for socket to appear", :client => @path)
-          sleep @socket_not_present_retry_interval_seconds
+          @logger.warn("Socket not present, wait for #{socket_not_present_retry_interval_seconds} seconds for socket to appear", :client => @path)
+          sleep socket_not_present_retry_interval_seconds
         end
       end
     end
@@ -158,6 +158,6 @@ class LogStash::Inputs::Unix < LogStash::Inputs::Base
   rescue IOError
     # if socket with @mode == client was closed by the client, an other call to @client_socket.close
     # will raise an IOError. We catch IOError here and do nothing, just let logstash terminate
-    @logger.warn("Cloud not close socket while Logstash is shutting down. Socket already closed by the other party?", :path => @path)
+    @logger.warn("Could not close socket while Logstash is shutting down. Socket already closed by the other party?", :path => @path)
   end # def stop
 end # class LogStash::Inputs::Unix

--- a/logstash-input-unix.gemspec
+++ b/logstash-input-unix.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-unix'
-  s.version         = '3.0.7'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events over a UNIX socket"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-unix.gemspec
+++ b/logstash-input-unix.gemspec
@@ -21,8 +21,9 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.3'
   s.add_runtime_dependency 'logstash-codec-line'
+
   s.add_development_dependency 'logstash-devutils'
 end
 

--- a/spec/inputs/unix_spec.rb
+++ b/spec/inputs/unix_spec.rb
@@ -57,7 +57,6 @@ describe LogStash::Inputs::Unix do
     context "when the unix socket has no data to be read" do
       it_behaves_like "an interruptible input plugin" do
         let(:run_forever) { false }
-        let(:allowed_lag) { 5 } # due Logstash 6.x in CI
       end
     end
 

--- a/spec/inputs/unix_spec.rb
+++ b/spec/inputs/unix_spec.rb
@@ -68,9 +68,10 @@ describe LogStash::Inputs::Unix do
 
       it 'generates events with host, path and message set' do
         subject.register
-        plugin_thread = Thread.new(subject, queue) { |subject, queue| subject.run(queue) }
-        expect(plugin_thread).to be_alive
-        try(10) { expect( queue ).to_not be_empty }
+        Thread.new(subject, queue) { |subject, queue| subject.run(queue) }
+        try(10) do
+          expect( queue.size ).to_not eql 0
+        end
         subject.do_stop # stop the plugin
 
         event = queue.first

--- a/spec/inputs/unix_spec.rb
+++ b/spec/inputs/unix_spec.rb
@@ -57,6 +57,7 @@ describe LogStash::Inputs::Unix do
     context "when the unix socket has no data to be read" do
       it_behaves_like "an interruptible input plugin" do
         let(:run_forever) { false }
+        let(:allowed_lag) { 5 } # due Logstash 6.x in CI
       end
     end
 

--- a/spec/inputs/unix_spec.rb
+++ b/spec/inputs/unix_spec.rb
@@ -64,7 +64,7 @@ describe LogStash::Inputs::Unix do
 
       let(:config) { super().merge 'ecs_compatibility' => ecs_compatibility }
 
-      let(:queue) { Array.new }
+      let(:queue) { java.util.Vector.new }
 
       it 'generates events with host, path and message set' do
         subject.register

--- a/spec/inputs/unix_spec.rb
+++ b/spec/inputs/unix_spec.rb
@@ -69,11 +69,10 @@ describe LogStash::Inputs::Unix do
       it 'generates events with host, path and message set' do
         subject.register
         plugin_thread = Thread.new(subject, queue) { |subject, queue| subject.run(queue) }
-        sleep 0.5
         expect(plugin_thread).to be_alive
+        try(10) { expect( queue ).to_not be_empty }
         subject.do_stop # stop the plugin
 
-        expect( queue ).to_not be_empty
         event = queue.first
 
         if ecs_select.active_mode == :disabled

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,8 +6,9 @@ class UnixSocketHelper
 
   attr_reader :path
 
-  def initialize
+  def initialize(line = 'hi!')
     @socket = nil
+    @line = line
   end
 
   def new_socket(path)
@@ -21,9 +22,9 @@ class UnixSocketHelper
     @thread = Thread.new do
       begin
         s = @socket.accept
-        s.puts "hi" while forever
-      rescue Errno::EPIPE, Errno::ECONNRESET
-        # ...
+        s.puts @line while forever
+      rescue Errno::EPIPE, Errno::ECONNRESET => e
+        warn e.inspect if $VERBOSE
       end
     end
     self


### PR DESCRIPTION
Since the plugin was setting fields that conflict with ECS schema, we're introducing an `ecs_compatibility` mode.
- legacy `host` becomes `[host][name]` in ECS mode
- the socket file `path` is now `[file][path]` in ECS mode

Also, fixed i-var name and logged message as reported in https://github.com/logstash-plugins/logstash-input-unix/issues/25


_**NOTE**: CI failures are not new - 6.x has [been broken](https://github.com/logstash-plugins/logstash-input-unix/runs/4223785388) for a long time. 
The problematic spec assumes a client socket blocking from [`readpartial`](https://github.com/logstash-plugins/logstash-input-unix/blob/v3.0.7/lib/logstash/inputs/unix.rb#L88) (while the server keep the socket open wout writing anything) to be interruptible on [`client_socket.close`](https://github.com/logstash-plugins/logstash-input-unix/blob/v3.0.7/lib/logstash/inputs/unix.rb#L156) - this is not the case and the only reason the spec does not hang CI is due the [teardown closing](https://github.com/logstash-plugins/logstash-input-unix/blob/v3.0.7/spec/inputs/unix_spec.rb#L47) the server socket -> leads to a EOF from the `readpartial`. 
Also the potential use of [`timeout`](https://github.com/logstash-plugins/logstash-input-unix/blob/v3.0.7/lib/logstash/inputs/unix.rb#L90) is problematic - a proper implementation would be to use `select` with a timeout and check for stopping periodically._