### PR TITLE
Fix: unable to stop plugin (on older versions of LS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.1.1
-  - Fix: unable to stop plugin (on older versions of LS) [#29](https://github.com/logstash-plugins/logstash-input-unix/pull/29)
+  - Fix: unable to stop plugin (on LS 6.x) [#29](https://github.com/logstash-plugins/logstash-input-unix/pull/29)
+  - Refactor: plugin internals got reviewed for `data_timeout => ...` to work reliably
 
 ## 3.1.0
   - Feat: adjust fields for ECS compatibility [#28](https://github.com/logstash-plugins/logstash-input-unix/pull/28) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.1
+  - Fix: unable to stop plugin (on older versions of LS) [#29](https://github.com/logstash-plugins/logstash-input-unix/pull/29)
+
 ## 3.1.0
   - Feat: adjust fields for ECS compatibility [#28](https://github.com/logstash-plugins/logstash-input-unix/pull/28) 
 

--- a/lib/logstash/inputs/unix.rb
+++ b/lib/logstash/inputs/unix.rb
@@ -136,7 +136,7 @@ class LogStash::Inputs::Unix < LogStash::Inputs::Base
       end
     else
       while !stop?
-        if File.socket?(@path) then
+        if File.socket?(@path)
           @client_socket = UNIXSocket.new(@path)
           @client_socket.instance_eval { class << self; include ::LogStash::Util::SocketPeer end }
           @logger.debug("Opened connection", :client => @path)

--- a/lib/logstash/inputs/unix.rb
+++ b/lib/logstash/inputs/unix.rb
@@ -88,7 +88,7 @@ class LogStash::Inputs::Unix < LogStash::Inputs::Base
 
         if data == :wait_readable
           if @data_timeout == -1 || IO.select([socket], nil, nil, @data_timeout)
-            retry # socket read operation
+            next # retry socket read
           else
             # socket not ready after @data_timeout seconds
             @logger.info("Closing connection after read timeout", :path => @path)

--- a/lib/logstash/inputs/unix.rb
+++ b/lib/logstash/inputs/unix.rb
@@ -15,8 +15,6 @@ class LogStash::Inputs::Unix < LogStash::Inputs::Base
 
   include LogStash::PluginMixins::ECSCompatibilitySupport(:disabled, :v1, :v8 => :v1)
 
-  class Interrupted < StandardError; end
-
   config_name "unix"
 
   default :codec, "line"

--- a/lib/logstash/inputs/unix.rb
+++ b/lib/logstash/inputs/unix.rb
@@ -138,7 +138,7 @@ class LogStash::Inputs::Unix < LogStash::Inputs::Base
       while !stop?
         if File.socket?(@path)
           @client_socket = UNIXSocket.new(@path)
-          @client_socket.instance_eval { class << self; include ::LogStash::Util::SocketPeer end }
+          @client_socket.extend ::LogStash::Util::SocketPeer
           @logger.debug("Opened connection", :client => @path)
           handle_socket(@client_socket, output_queue)
         else

--- a/logstash-input-unix.gemspec
+++ b/logstash-input-unix.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-unix'
-  s.version         = '3.1.0'
+  s.version         = '3.1.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events over a UNIX socket"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,7 @@ class UnixSocketHelper
   end
 
   def new_socket(path)
-    @path   = path
+    @path = path
     File.unlink if File.exists?(path) && File.socket?(path)
     @socket = UNIXServer.new(path)
     self
@@ -31,7 +31,6 @@ class UnixSocketHelper
   end
 
   def close
-    @thread.kill
     @socket.close
     File.unlink(path)
   end


### PR DESCRIPTION
Plugin has been failing CI for a long time on [6.x](https://github.com/logstash-plugins/logstash-input-unix/runs/4223785388) for a long time. 

The problematic spec assumes a client socket blocking from [`readpartial`](https://github.com/logstash-plugins/logstash-input-unix/blob/v3.0.7/lib/logstash/inputs/unix.rb#L88) (while the server keep the socket open wout writing anything) to be interruptible on [`client_socket.close`](https://github.com/logstash-plugins/logstash-input-unix/blob/v3.0.7/lib/logstash/inputs/unix.rb#L156) - this is not the case and the only reason the spec does not hang CI is due the [teardown closing](https://github.com/logstash-plugins/logstash-input-unix/blob/v3.0.7/spec/inputs/unix_spec.rb#L47) the server socket -> leads to a EOF from the `readpartial`. 
Seems this has been "broken" on JRuby 9.2.7.0 (LS 6.8.x) and closing a socket stuck in `readpartial` hangs.

The failure aksi revealed a deeper (timeout) issue in terms of how the plugin works.
The potential use of [`timeout`](https://github.com/logstash-plugins/logstash-input-unix/blob/v3.0.7/lib/logstash/inputs/unix.rb#L90) is problematic - a proper implementation would be to use `select` with a timeout and check for stopping periodically.