### PR TITLE
data_timeout: decouple blocking duration from data timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.1.2
-  - Fix: eliminate high CPU usage when data timeout is disabled and no data is available on the socket
+  - Fix: eliminate high CPU usage when data timeout is disabled and no data is available on the socket [#30](https://github.com/logstash-plugins/logstash-input-unix/pull/30)
 
 ## 3.1.1
   - Fix: unable to stop plugin (on LS 6.x) [#29](https://github.com/logstash-plugins/logstash-input-unix/pull/29)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.2
+  - Fix: eliminate high CPU usage when data timeout is disabled and no data is available on the socket
+
 ## 3.1.1
   - Fix: unable to stop plugin (on LS 6.x) [#29](https://github.com/logstash-plugins/logstash-input-unix/pull/29)
   - Refactor: plugin internals got reviewed for `data_timeout => ...` to work reliably

--- a/logstash-input-unix.gemspec
+++ b/logstash-input-unix.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-unix'
-  s.version         = '3.1.1'
+  s.version         = '3.1.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events over a UNIX socket"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
RETROACTIVE EDIT TO HIGHLIGHT ISSUE

v3.1.1 of this plugin made changes to attempt to make the plugin more-interruptible, but had the undesired side-effect of very high CPU in the default configuration of `data_timeout => -1` (no timeout, read repeatedly until socket stops existing). 

A workaround was suggested along with the bug report to set the `data_timeout` to a very high number (like `315360000` "ten years") which prevents the high-CPU issue, but a plugin in this configuration connected to a socket that was not receiving traffic could not be interrupted because it is blocking on `IO#Select` for the entire `data_timeout` and not checking for plugin shutdown state.

In order to both observe shutdown state and the default no-timeout for the data channel, we need to decouple blocking IO limits from our `data_timeout`.

***


Introduces `Unix#io_interruptable_readpartial`, which emulates `IO#readpartial` while observing both the plugin's stop condition and an optional timeout.

Internally, this helper limits its blocking calls to 10s or less whether or not the plugin is configured with a `data_timeout`, allowing it to periodically observe the plugin's stop condition to exit gracefully in a reasonable amount of time when the socket is not receiving writes.

This fixes a regression introduced in v3.1.1 of this plugin (#29) in which the default configuration of `data_timeout => -1` (timeout disabled) consumed excess CPU attempting non-blocking reads of the IO when it had no readable bytes.
