### PR TITLE
Replace File.exists? with File.exist?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.3
+  - Fix: replace deprecated `File.exists?` with `File.exist?` for Ruby 3.4 (JRuby 10) compatibility [#31](https://github.com/logstash-plugins/logstash-input-unix/pull/31)
+
 ## 3.1.2
   - Fix: eliminate high CPU usage when data timeout is disabled and no data is available on the socket [#30](https://github.com/logstash-plugins/logstash-input-unix/pull/30)
 

--- a/logstash-input-unix.gemspec
+++ b/logstash-input-unix.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-unix'
-  s.version         = '3.1.2'
+  s.version         = '3.1.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events over a UNIX socket"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@ class UnixSocketHelper
 
   def new_socket(path)
     @path = path
-    File.unlink if File.exists?(path) && File.socket?(path)
+    File.unlink if File.exist?(path) && File.socket?(path)
     @socket = UNIXServer.new(path)
     self
   end


### PR DESCRIPTION
## Summary
- Replace `File.exists?` with `File.exist?` in spec helper for Ruby 3.4 compatibility

`File.exists?` was deprecated in Ruby 3.2 and has been removed in Ruby 3.4 (JRuby 10). `File.exist?` has been the preferred method since Ruby 1.0.